### PR TITLE
🐛 Initial WiFi setup bugfix

### DIFF
--- a/library.json
+++ b/library.json
@@ -26,5 +26,5 @@
     "license": "MIT",
     "frameworks": "arduino",
     "platforms": "*",
-    "version": "0.1.0"
+    "version": "0.1.1"
 }

--- a/src/knock.cpp
+++ b/src/knock.cpp
@@ -179,8 +179,10 @@ void KnockClass::onWrite(BLECharacteristic *pCharacteristic) {
 
     if (pCharacteristic->getUUID().equals(CHAR_WIFI_SSID)) {
         preferences.putString(PREF_WIFI_SSID, value.c_str());
+        WIFI_SSID = value.c_str();
     } else if (pCharacteristic->getUUID().equals(CHAR_WIFI_PASS)) {
         preferences.putString(PREF_WIFI_PASS, value.c_str());
+        WIFI_PASS = value.c_str();
     } else if (pCharacteristic->getUUID().equals(CHAR_WIFI_START)) {
         this->setup_wifi();
     }

--- a/src/knock.h
+++ b/src/knock.h
@@ -6,6 +6,7 @@ class KnockClass: public BLECharacteristicCallbacks, BLEServerCallbacks {
 private:
     bool _is_ble_connected;
     bool _is_wifi_connected;
+    unsigned long wifi_timeout_ms;
 
     static void init();
 


### PR DESCRIPTION
- Fixes issue where ssid/pass is saved to NVM but not set to local vars on initial setup
- Attempt connection on initialization if we have credentials
- Don't infinite loop if we have a WiFi connection error / timeout